### PR TITLE
Don't force_ssl; Enable multi-arch builds

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -39,5 +39,6 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ COPY --from=build /usr/include/node /usr/include/node
 
 # Run and own only the runtime files as a non-root user for security
 RUN useradd rails --create-home --shell /bin/bash && \
+    mkdir -p db log tmp && \
     chown -R rails:rails db log tmp
 USER rails:rails
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = false
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
We don't need to force_ssl on the rails application and ingress controller can handle that.

Also adds a fix for the missing `log` dir and enables multi-arch builds